### PR TITLE
Support hash table "aliasing". During emplace `args` may directly or indirectly refer to a value in the container.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ set(TEST_SOURCES
   ExcaliburHashTest01.cpp
   ExcaliburHashTest02.cpp
   ExcaliburHashTest03.cpp
+  ExcaliburHashTest04.cpp
 )
+
 set (TEST_EXE_NAME ${PROJ_NAME})
 add_executable(${TEST_EXE_NAME} ${TEST_SOURCES})
 

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -624,7 +624,7 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
     template <typename TK, class... Args> inline std::pair<IteratorKV, bool> emplace(TK&& key, Args&&... args)
     {
         static_assert(std::is_same<TKey, typename std::remove_const<typename std::remove_reference<TK>::type>::type>::value,
-                      "Expected unversal reference of TKey type");
+                      "Expected unversal reference of TKey type. Wrong key type?");
 
         EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getTombstone(), key));
         EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getEmpty(), key));

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -288,40 +288,6 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
         }
     }
 
-    inline void grow(uint32_t numBucketsNew)
-    {
-        const uint32_t numBuckets = m_numBuckets;
-        TItem* storage = m_storage;
-        TItem* EXLBR_RESTRICT item = storage;
-        TItem* const enditem = item + numBuckets;
-        bool isInlineStorage = isUsingInlineStorage();
-
-        // m_storage = nullptr;
-        // m_numBuckets = 0;
-        create(numBucketsNew);
-
-        for (; item != enditem; item++)
-        {
-            if (item->isValid())
-            {
-                if constexpr (has_values::value)
-                {
-                    emplace(std::move(*item->key()), std::move(*item->value()));
-                }
-                else
-                {
-                    emplace(std::move(*item->key()));
-                }
-            }
-            destruct(item);
-        }
-
-        if (!isInlineStorage)
-        {
-            EXLBR_FREE(storage);
-        }
-    }
-
     [[nodiscard]] inline bool isUsingInlineStorage() const noexcept
     {
         const TItem* inlineStorage = reinterpret_cast<const TItem*>(&m_inlineStorage);
@@ -335,7 +301,7 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
         return inlineItem;
     }
 
-    inline void create(uint32_t numBuckets)
+    inline uint32_t create(uint32_t numBuckets)
     {
         numBuckets = (numBuckets < k_MinNumberOfBuckets) ? k_MinNumberOfBuckets : numBuckets;
 
@@ -364,6 +330,8 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
         {
             construct<TItem>(item, TKeyInfo::getEmpty());
         }
+
+        return numBuckets;
     }
 
     inline void destroy()
@@ -621,23 +589,10 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
         m_numElements = 0;
     }
 
-    template <typename TK, class... Args> inline std::pair<IteratorKV, bool> emplace(TK&& key, Args&&... args)
+  private:
+
+    template <typename TK, class... Args> inline std::pair<IteratorKV, bool> emplace_no_grow(uint32_t numBuckets, TK&& key, Args&&... args)
     {
-        static_assert(std::is_same<TKey, typename std::remove_const<typename std::remove_reference<TK>::type>::type>::value,
-                      "Expected unversal reference of TKey type. Wrong key type?");
-
-        EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getTombstone(), key));
-        EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getEmpty(), key));
-        uint32_t numBuckets = m_numBuckets;
-
-        // numBucketsThreshold = (numBuckets * 3/4) (but implemented using bit shifts)
-        const uint32_t numBucketsThreshold = shr(numBuckets, 1u) + shr(numBuckets, 2u);
-        if (m_numElements > numBucketsThreshold)
-        {
-            grow(numBuckets * 2);
-            numBuckets = m_numBuckets;
-        }
-
         // numBuckets has to be power-of-two
         EXLBR_ASSERT(numBuckets > 0);
         EXLBR_ASSERT((numBuckets & (numBuckets - 1)) == 0);
@@ -675,6 +630,71 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
             currentItem++;
             currentItem = (currentItem == endItem) ? firstItem : currentItem;
         }
+    }
+
+    template <typename TK, class... Args>
+    inline std::pair<IteratorKV, bool> grow_and_emplace(uint32_t numBucketsNew, TK&& key, Args&&... args)
+    {
+        const uint32_t numBuckets = m_numBuckets;
+        TItem* storage = m_storage;
+        TItem* EXLBR_RESTRICT item = storage;
+        TItem* const enditem = item + numBuckets;
+        bool isInlineStorage = isUsingInlineStorage();
+
+        numBucketsNew = create(numBucketsNew);
+
+        //
+        // insert a new element (one of the args might still point to the old storage in case of hash table 'aliasing'
+        //
+        // i.e.
+        // auto it = table.find("key");
+        // table.emplace("another_key", it->second);   // <--- when hash table grows it->second will point to a memory we are about to free
+        auto it = emplace_no_grow(numBucketsNew, key, args...);
+
+        // re-insert existing elements
+        for (; item != enditem; item++)
+        {
+            if (item->isValid())
+            {
+                if constexpr (has_values::value)
+                {
+                    emplace_no_grow(numBucketsNew, std::move(*item->key()), std::move(*item->value()));
+                }
+                else
+                {
+                    emplace_no_grow(numBucketsNew, std::move(*item->key()));
+                }
+            }
+            destruct(item);
+        }
+
+        if (!isInlineStorage)
+        {
+            EXLBR_FREE(storage);
+        }
+
+        return it;
+    }
+
+
+  public:
+    template <typename TK, class... Args> inline std::pair<IteratorKV, bool> emplace(TK&& key, Args&&... args)
+    {
+        static_assert(std::is_same<TKey, typename std::remove_const<typename std::remove_reference<TK>::type>::type>::value,
+                      "Expected unversal reference of TKey type. Wrong key type?");
+
+        EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getTombstone(), key));
+        EXLBR_ASSERT(!TKeyInfo::isEqual(TKeyInfo::getEmpty(), key));
+        uint32_t numBuckets = m_numBuckets;
+
+        // numBucketsThreshold = (numBuckets * 3/4) (but implemented using bit shifts)
+        const uint32_t numBucketsThreshold = shr(numBuckets, 1u) + shr(numBuckets, 2u);
+        if (m_numElements > numBucketsThreshold)
+        {
+            return grow_and_emplace(numBuckets * 2, key, args...);
+        }
+
+        return emplace_no_grow(numBuckets, key, args...);
     }
 
     [[nodiscard]] inline ConstIteratorKV find(const TKey& key) const noexcept
@@ -728,14 +748,44 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
         return erase(it);
     }
 
-    inline bool reserve(uint32_t numBuckets)
+    inline bool reserve(uint32_t numBucketsNew)
     {
-        if (numBuckets == 0 || numBuckets < capacity())
+        if (numBucketsNew == 0 || numBucketsNew < capacity())
         {
             return false;
         }
-        numBuckets = nextPow2(numBuckets);
-        grow(numBuckets);
+        numBucketsNew = nextPow2(numBucketsNew);
+
+        const uint32_t numBuckets = m_numBuckets;
+        TItem* storage = m_storage;
+        TItem* EXLBR_RESTRICT item = storage;
+        TItem* const enditem = item + numBuckets;
+        bool isInlineStorage = isUsingInlineStorage();
+
+        numBucketsNew = create(numBucketsNew);
+
+        // re-insert existing elements
+        for (; item != enditem; item++)
+        {
+            if (item->isValid())
+            {
+                if constexpr (has_values::value)
+                {
+                    emplace_no_grow(numBucketsNew, std::move(*item->key()), std::move(*item->value()));
+                }
+                else
+                {
+                    emplace_no_grow(numBucketsNew, std::move(*item->key()));
+                }
+            }
+            destruct(item);
+        }
+
+        if (!isInlineStorage)
+        {
+            EXLBR_FREE(storage);
+        }
+
         return true;
     }
 

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -18,6 +18,7 @@ struct ComplexValue
         EXPECT_FALSE(other.isDeleted);
         isMoved = other.isMoved;
         isDeleted = other.isDeleted;
+        return *this;
     }
 
     ComplexValue() noexcept

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -6,59 +6,53 @@ struct ComplexValue
 {
     ComplexValue(const ComplexValue& other)
         : isMoved(other.isMoved)
+        , isDeleted(other.isDeleted)
     {
-        /*
-        if (other.isMoved)
-        {
-            int a = 0;
-            a = 7;
-        }
-        */
         EXPECT_FALSE(other.isMoved);
+        EXPECT_FALSE(other.isDeleted);
     }
 
     ComplexValue& operator=(const ComplexValue& other) noexcept
     {
-        /*
-        if (other.isMoved)
-        {
-            int a = 0;
-            a = 7;
-        }
-        */
-
         EXPECT_FALSE(other.isMoved);
+        EXPECT_FALSE(other.isDeleted);
         isMoved = other.isMoved;
+        isDeleted = other.isDeleted;
     }
 
     ComplexValue() noexcept
         : isMoved(false)
+        , isDeleted(false)
     {
     }
 
     ComplexValue(ComplexValue&& other) noexcept
         : isMoved(other.isMoved)
+        , isDeleted(other.isDeleted)
     {
+        EXPECT_FALSE(other.isDeleted);
         other.isMoved = true;
     }
 
-    ~ComplexValue() noexcept {}
+    ~ComplexValue() noexcept { isDeleted = true; }
 
     ComplexValue& operator=(ComplexValue&& other) noexcept
     {
+        isDeleted = other.isDeleted;
         isMoved = other.isMoved;
         other.isMoved = true;
         return *this;
     }
 
     bool isMoved;
+    bool isDeleted;
 };
 
 TEST(SmFlatHashMap, InsertFromItselfWhileGrow)
 {
     for (int i = 1; i <= 1000; i++)
     {
-        //printf("Step %d\n", i);
+        // printf("Step %d\n", i);
 
         // create hash map and insert one element
         Excalibur::HashTable<int, ComplexValue> ht;

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -49,6 +49,7 @@ struct ComplexValue
     bool isDeleted;
 };
 
+
 TEST(SmFlatHashMap, InsertFromItselfWhileGrow)
 {
     for (int i = 1; i <= 1000; i++)

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -1,0 +1,83 @@
+#include "ExcaliburHash.h"
+#include "gtest/gtest.h"
+#include <array>
+
+struct ComplexValue
+{
+    ComplexValue(const ComplexValue& other)
+        : isMoved(other.isMoved)
+    {
+        /*
+        if (other.isMoved)
+        {
+            int a = 0;
+            a = 7;
+        }
+        */
+        EXPECT_FALSE(other.isMoved);
+    }
+
+    ComplexValue& operator=(const ComplexValue& other) noexcept
+    {
+        /*
+        if (other.isMoved)
+        {
+            int a = 0;
+            a = 7;
+        }
+        */
+
+        EXPECT_FALSE(other.isMoved);
+        isMoved = other.isMoved;
+    }
+
+    ComplexValue() noexcept
+        : isMoved(false)
+    {
+    }
+
+    ComplexValue(ComplexValue&& other) noexcept
+        : isMoved(other.isMoved)
+    {
+        other.isMoved = true;
+    }
+
+    ~ComplexValue() noexcept {}
+
+    ComplexValue& operator=(ComplexValue&& other) noexcept
+    {
+        isMoved = other.isMoved;
+        other.isMoved = true;
+        return *this;
+    }
+
+    bool isMoved;
+};
+
+TEST(SmFlatHashMap, InsertFromItselfWhileGrow)
+{
+    for (int i = 1; i <= 1000; i++)
+    {
+        //printf("Step %d\n", i);
+
+        // create hash map and insert one element
+        Excalibur::HashTable<int, ComplexValue> ht;
+
+        // insert some elements into the hash maps
+        for (int j = 0; j < i; j++)
+        {
+            ht.emplace(j, ComplexValue{});
+        }
+
+        // find the first inserted element (get a valid iterator)
+        auto it = ht.find(0);
+        ASSERT_NE(it, ht.end());
+
+        // insert a new element using the above iterator
+        // (a hash map can grow during insertion and this could invalidate the iterator)
+        ht.emplace(-1, it->second);
+
+        auto it2 = ht.find(-1);
+        ASSERT_NE(it2, ht.end());
+    }
+}


### PR DESCRIPTION
Support hash table "aliasing". During emplace, args may directly or indirectly refer to a value in the container

Similar to std::vector<T>

The arguments args... are forwarded to the constructor as std::forward<Args>(args).... args... may directly or indirectly refer to a value in the container.