### PR TITLE
Erase now returns a valid iterator

### DIFF
--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -436,6 +436,12 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
       public:
         IteratorBase() = delete;
 
+        IteratorBase(const IteratorBase& other) noexcept
+            : m_ht(other.m_ht)
+            , m_item(other.m_item)
+        {
+        }
+
         IteratorBase(const HashTable* ht, TItem* item) noexcept
             : m_ht(ht)
             , m_item(item)
@@ -542,9 +548,16 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
       public:
         TIteratorKV() = delete;
 
+        TIteratorKV(const TIteratorKV& other)
+            : IteratorBase(other)
+            , tmpKv(reference<const TKey>(nullptr), reference<TIteratorValue>(nullptr))
+        {
+        }
+
         TIteratorKV& operator=(const TIteratorKV& other) noexcept
         {
             IteratorBase::copyFrom(other);
+            // note: we'll automatically update tmpKv on the next access = no need to copy
             return *this;
         }
 

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -427,6 +427,12 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
             return item;
         }
 
+        void copyFrom(const IteratorBase& other)
+        {
+            m_ht = other.m_ht;
+            m_item = other.m_item;
+        }
+
       public:
         IteratorBase() = delete;
 
@@ -535,6 +541,12 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>> cla
 
       public:
         TIteratorKV() = delete;
+
+        TIteratorKV& operator=(const TIteratorKV& other) noexcept
+        {
+            IteratorBase::copyFrom(other);
+            return *this;
+        }
 
         TIteratorKV(const HashTable* ht, TItem* item) noexcept
             : IteratorBase(ht, item)

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -136,12 +136,12 @@ TEST(SmFlatHashMap, CopyableIterators)
     {
         for (Excalibur::HashTable<std::string, std::string>::IteratorKV it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
         {
-            if (_stricmp(it3->first.get().c_str(), "5") == 0)
+            if (std::strcmp(it3->first.get().c_str(), "5") == 0)
             {
                 it3 = ht.erase(it3);
             }
 
-            if (_stricmp(it3->first.get().c_str(), "9") == 0)
+            if (std::strcmp(it3->first.get().c_str(), "9") == 0)
             {
                 it3 = ht.erase(it3);
             }

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -116,13 +116,18 @@ TEST(SmFlatHashMap, CopyableIterators)
     ++it2;
     EXPECT_NE(it, it2);
 
+    it2 = it;
+    EXPECT_EQ(it, it2);
+
+/*
     printf("pass1\n");
-    for (auto it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
+    for (Excalibur::HashTable<std::string, std::string>::IteratorKV it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
     {
         printf("%s:%s\n", it3->first.get().c_str(), it3->second.get().c_str());
         if (_stricmp(it3->first.get().c_str(), "5") == 0)
         {
-            ht.erase(it3);
+            ht.eraseImpl(it3);
+            auto it33 = ht.erase(it3);
         }
 
         if (_stricmp(it3->first.get().c_str(), "9") == 0)
@@ -136,4 +141,5 @@ TEST(SmFlatHashMap, CopyableIterators)
     {
         printf("%s:%s\n", it3->first.get().c_str(), it3->second.get().c_str());
     }
+*/
 }

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -97,11 +97,13 @@ TEST(SmFlatHashMap, CopyableIterators)
 {
     Excalibur::HashTable<std::string, std::string> ht;
 
-    for (int i = 1; i < 16; i++)
+    int sum = 0;
+    for (int i = 1; i <= 16; i++)
     {
-        ht.emplace(std::to_string(i), std::to_string(i+1));
+        ht.emplace(std::to_string(i), std::to_string(i + 1));
+        sum += i;
     }
-    
+
     Excalibur::HashTable<std::string, std::string>::IteratorKV it = ht.find(std::to_string(1));
     ASSERT_NE(it, ht.end());
     const std::string& val = it->second;
@@ -119,27 +121,58 @@ TEST(SmFlatHashMap, CopyableIterators)
     it2 = it;
     EXPECT_EQ(it, it2);
 
-/*
-    printf("pass1\n");
-    for (Excalibur::HashTable<std::string, std::string>::IteratorKV it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
+    // capture before state
+    std::vector<std::string> before;
     {
-        printf("%s:%s\n", it3->first.get().c_str(), it3->second.get().c_str());
-        if (_stricmp(it3->first.get().c_str(), "5") == 0)
+        for (auto it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
         {
-            ht.eraseImpl(it3);
-            auto it33 = ht.erase(it3);
+            before.emplace_back(it3->first);
         }
+        std::sort(before.begin(), before.end());
+    }
 
-        if (_stricmp(it3->first.get().c_str(), "9") == 0)
+
+    // iterate and remove
+    {
+        for (Excalibur::HashTable<std::string, std::string>::IteratorKV it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
         {
-            ht.erase(it3);
+            if (_stricmp(it3->first.get().c_str(), "5") == 0)
+            {
+                it3 = ht.erase(it3);
+            }
+
+            if (_stricmp(it3->first.get().c_str(), "9") == 0)
+            {
+                it3 = ht.erase(it3);
+            }
         }
     }
 
-    printf("pass2\n");
-    for (auto it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
+    // capture after state
+    std::vector<std::string> after;
     {
-        printf("%s:%s\n", it3->first.get().c_str(), it3->second.get().c_str());
+        for (auto it3 = ht.ibegin(); it3 != ht.iend(); ++it3)
+        {
+            after.emplace_back(it3->first);
+        }
+
+        std::sort(after.begin(), after.end());
     }
-*/
+
+    // make sure we've got the expected results
+    int sumBefore = 0;
+    for (const std::string& v : before)
+    {
+        int iv = std::stoi(v);
+        sumBefore += iv;
+    }
+    EXPECT_EQ(sumBefore, sum);
+
+    int sumAfter = 0;
+    for (const std::string& v : after)
+    {
+        int iv = std::stoi(v);
+        sumAfter += iv;
+    }
+    EXPECT_EQ(sumBefore-5-9, sumAfter);
 }

--- a/ExcaliburHashTest04.cpp
+++ b/ExcaliburHashTest04.cpp
@@ -1,6 +1,7 @@
 #include "ExcaliburHash.h"
 #include "gtest/gtest.h"
 #include <array>
+#include <cstring>
 
 namespace Excalibur
 {


### PR DESCRIPTION
`Erase()` now returns an iterator following the last removed element (similar to std)
The following code is now formally "legalized" and covered with unit tests.

```
Excalibur::HashTable<int, int> ht;
for (auto it = ht.ibegin(); it != ht.iend(); ++it)
{
  if (...condition...)
  {
    it = ht.erase(it);
  }
}
```