### PR TITLE
Configurable inplace storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCES
   ExcaliburHashTest02.cpp
   ExcaliburHashTest03.cpp
   ExcaliburHashTest04.cpp
+  ExcaliburHashTest05.cpp
 )
 
 set (TEST_EXE_NAME ${PROJ_NAME})

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -992,6 +992,6 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
 template <typename TKey, typename TValue> using HashMap = HashTable<TKey, TValue, 1, KeyInfo<TKey>>;
 
 // hashset declaration
-template <typename TKey> using HashSet = HashTable<TKey, nullptr_t, 1, KeyInfo<TKey>>;
+template <typename TKey> using HashSet = HashTable<TKey, std::nullptr_t, 1, KeyInfo<TKey>>;
 
 } // namespace Excalibur

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -320,7 +320,7 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
                 TItem& otherInlineItem = from[i];
                 const bool hasValidValue = otherInlineItem.isValid();
                 construct<TItem>((inlineItems + i), std::move(*otherInlineItem.key()));
-                
+
                 // move inline storage value (if any)
                 if (hasValidValue)
                 {
@@ -333,7 +333,7 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
         }
         else
         {
-            // move only keys 
+            // move only keys
             for (unsigned i = 0; i < kNumInlineItems; i++)
             {
                 construct<TItem>((inlineItems + i), std::move(*from[i].key()));
@@ -1006,9 +1006,16 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
     uint32_t m_numBuckets;  // 4
     uint32_t m_numElements; // 4
 
+    template <typename INTEGRAL_TYPE> inline static constexpr bool isPow2(INTEGRAL_TYPE x) noexcept
+    {
+        static_assert(std::is_integral<INTEGRAL_TYPE>::value, "isPow2 must be called on an integer type.");
+        return (x & (x - 1)) == 0 && (x != 0);
+    }
+
     // We need this inline storage to keep `m_storage` not null all the time.
     // This will save us from `empty()` check inside `find()` function implementation
     static_assert(kNumInlineItems != 0, "Num inline items can't be zero!");
+    static_assert(isPow2(kNumInlineItems), "Num inline items should be power of two");
     typename std::aligned_storage<sizeof(TItem) * kNumInlineItems, alignof(TItem)>::type m_inlineStorage;
     static_assert(sizeof(m_inlineStorage) == (sizeof(TItem) * kNumInlineItems), "Incorrect sizeof");
 };

--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -112,7 +112,7 @@ TODO: Design descisions/principles
 TODO: Memory layout
 
 */
-template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>, unsigned kNumInlineItems = 1> class HashTable
+template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename TKeyInfo = KeyInfo<TKey>> class HashTable
 {
     struct has_values : std::bool_constant<!std::is_same<std::nullptr_t, typename std::remove_reference<TValue>::type>::value>
     {
@@ -502,7 +502,7 @@ template <typename TKey, typename TValue, typename TKeyInfo = KeyInfo<TKey>, uns
       protected:
         const HashTable* m_ht;
         TItem* m_item;
-        friend class HashTable<TKey, TValue, TKeyInfo, kNumInlineItems>;
+        friend class HashTable<TKey, TValue, kNumInlineItems, TKeyInfo>;
     };
 
     class IteratorK : public IteratorBase

--- a/ExcaliburHashTest02.cpp
+++ b/ExcaliburHashTest02.cpp
@@ -60,7 +60,7 @@ TEST(SmFlatHashMap, CtorDtorCallCount)
 
     {
         // empty hash table
-        Excalibur::HashTable<ComplexStruct, int, Excalibur::KeyInfo<ComplexStruct>, 4> ht;
+        Excalibur::HashTable<ComplexStruct, int, 4> ht;
         EXPECT_TRUE(ht.empty());
         EXPECT_EQ(ht.size(), 0u);
         EXPECT_GE(ht.capacity(), 0u);

--- a/ExcaliburHashTest02.cpp
+++ b/ExcaliburHashTest02.cpp
@@ -60,7 +60,7 @@ TEST(SmFlatHashMap, CtorDtorCallCount)
 
     {
         // empty hash table
-        Excalibur::HashTable<ComplexStruct, int> ht;
+        Excalibur::HashTable<ComplexStruct, int, Excalibur::KeyInfo<ComplexStruct>, 4> ht;
         EXPECT_TRUE(ht.empty());
         EXPECT_EQ(ht.size(), 0u);
         EXPECT_GE(ht.capacity(), 0u);

--- a/ExcaliburHashTest05.cpp
+++ b/ExcaliburHashTest05.cpp
@@ -1,0 +1,64 @@
+#include "ExcaliburHash.h"
+#include "gtest/gtest.h"
+#include <array>
+#include <cstring>
+
+namespace Excalibur
+{
+template <> struct KeyInfo<std::string>
+{
+    static inline bool isValid(const std::string& key) noexcept { return !key.empty() && key.data()[0] != char(1); }
+    static inline std::string getTombstone() noexcept
+    {
+        // and let's hope that small string optimization will do the job
+        return std::string(1, char(1));
+    }
+    static inline std::string getEmpty() noexcept { return std::string(); }
+    static inline uint64_t hash(const std::string& key) noexcept { return std::hash<std::string>{}(key); }
+    static inline bool isEqual(const std::string& lhs, const std::string& rhs) noexcept { return lhs == rhs; }
+};
+} // namespace Excalibur
+
+TEST(SmFlatHashMap, InlineStorageTest01)
+{
+    // create hash map and insert one element
+    Excalibur::HashTable<std::string, std::string, Excalibur::KeyInfo<std::string>, 4> ht;
+
+    EXPECT_GE(ht.capacity(), uint32_t(4));
+
+    auto it1 = ht.emplace(std::string("hello1"), std::string("world1"));
+    EXPECT_TRUE(it1.second);
+    auto it2 = ht.emplace(std::string("hello2"), std::string("world2"));
+    EXPECT_TRUE(it2.second);
+
+    EXPECT_EQ(ht.size(), uint32_t(2));
+
+    {
+        auto _it1 = ht.find("hello1");
+        ASSERT_NE(_it1, ht.end());
+        const std::string& val1 = _it1->second;
+        ASSERT_EQ(val1, "world1");
+
+        auto _it2 = ht.find("hello2");
+        ASSERT_NE(_it2, ht.end());
+        const std::string& val2 = _it2->second;
+        ASSERT_EQ(val2, "world2");
+    }
+
+    for (int i = 0; i < 1000; i++)
+    {
+        ht.emplace(std::to_string(i), "tmp");
+    }
+
+    {
+        auto _it1 = ht.find("hello1");
+        ASSERT_NE(_it1, ht.end());
+        const std::string& val1 = _it1->second;
+        ASSERT_EQ(val1, "world1");
+
+        auto _it2 = ht.find("hello2");
+        ASSERT_NE(_it2, ht.end());
+        const std::string& val2 = _it2->second;
+        ASSERT_EQ(val2, "world2");
+    }
+}

--- a/ExcaliburHashTest05.cpp
+++ b/ExcaliburHashTest05.cpp
@@ -62,3 +62,49 @@ TEST(SmFlatHashMap, InlineStorageTest01)
         ASSERT_EQ(val2, "world2");
     }
 }
+
+
+TEST(SmFlatHashMap, AliasNameTest)
+{
+    {
+        Excalibur::HashMap<int, int> hm;
+        auto it1 = hm.emplace(1, 2);
+        EXPECT_TRUE(it1.second);
+        auto it2 = hm.emplace(2, 3);
+        EXPECT_TRUE(it2.second);
+
+        auto _it1 = hm.find(1);
+        ASSERT_NE(_it1, hm.end());
+
+        auto _it2 = hm.find(2);
+        ASSERT_NE(_it2, hm.end());
+
+        auto _it3 = hm.find(3);
+        ASSERT_EQ(_it3, hm.end());
+
+        const int& val1 = _it1->second;
+        const int& val2 = _it2->second;
+        ASSERT_EQ(val1, 2);
+        ASSERT_EQ(val2, 3);
+    }
+
+    {
+        Excalibur::HashSet<int> hs;
+        auto it1 = hs.emplace(1);
+        EXPECT_TRUE(it1.second);
+        auto it2 = hs.emplace(1);
+        EXPECT_FALSE(it2.second);
+        auto it3 = hs.emplace(2);
+        EXPECT_TRUE(it3.second);
+
+        EXPECT_TRUE(hs.has(1));
+        EXPECT_TRUE(hs.has(2));
+        EXPECT_FALSE(hs.has(3));
+    }
+
+
+
+
+
+
+}

--- a/ExcaliburHashTest05.cpp
+++ b/ExcaliburHashTest05.cpp
@@ -22,7 +22,7 @@ template <> struct KeyInfo<std::string>
 TEST(SmFlatHashMap, InlineStorageTest01)
 {
     // create hash map and insert one element
-    Excalibur::HashTable<std::string, std::string, Excalibur::KeyInfo<std::string>, 4> ht;
+    Excalibur::HashTable<std::string, std::string, 8> ht;
 
     EXPECT_GE(ht.capacity(), uint32_t(4));
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ It uses an open addressing hash table and manages removed items with a method ca
 Engineered for ease of use, Excalibur Hash, in a vast majority of cases (99%), serves as a seamless, drop-in alternative to std::unordered_map. However, it's important to note that Excalibur Hash does not guarantee stable addressing.
 So, if your project needs to hold direct pointers to the keys or values, Excalibur Hash might not work as you expect. This aside, its design and efficiency make it a great choice for applications where speed is crucial.
 
+## Features
+
+1. Extremely fast (see Performance section for details)
+2. CPU cache friendly
+3. Built-in configurable inline storage
+4. Can either work as a map (key, value) or as a set (keys only)
+
+
 ## Performance
 
 In this section, you can see a performance comparison against a few popular hash table implementations.


### PR DESCRIPTION
1. Add configurable inplace storage
2. Fix the issue with an incorrect second argument returned from `pair<it, bool>emplace();` when the hash table grow
3. Performance optimizations
4. Add more tests