### PR TITLE
Fix infinite loop when emplace() is called with no empty slots

### DIFF
--- a/ExcaliburHash/ExcaliburHash.h
+++ b/ExcaliburHash/ExcaliburHash.h
@@ -637,7 +637,8 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
         const size_t bucketIndex = hashValue & (numBuckets - 1);
         TItem* const firstItem = m_storage;
         TItem* const endItem = firstItem + numBuckets;
-        TItem* EXLBR_RESTRICT currentItem = firstItem + bucketIndex;
+        TItem* const startItem = firstItem + bucketIndex;
+        TItem* EXLBR_RESTRICT currentItem = startItem;
         TItem* EXLBR_RESTRICT insertItem = nullptr;
 
         while (true)
@@ -646,7 +647,7 @@ template <typename TKey, typename TValue, unsigned kNumInlineItems = 1, typename
             {
                 return std::make_pair(IteratorKV(this, currentItem), false);
             }
-            if (currentItem->isEmpty())
+            if (currentItem->isEmpty() || (insertItem && currentItem == startItem))
             {
                 insertItem = ((insertItem == nullptr) ? currentItem : insertItem);
 


### PR DESCRIPTION
Hello

We encountered this, which I believe is a bug, in our usage of ExcaliburHash

Basically, if a HashMap has only Tombstones left, but no Empty slots anymore, `emplace()` will loop infinitely

My attempt to fix, with a very rough understanding of linear probing and tombstones, is that once we've completed a loop over all elements (reached `startItem`) we can safely insert in the first encountered tombstone as we are sure there are no duplicate keys
